### PR TITLE
Add script to verify links

### DIFF
--- a/hack/markdown-link-check.json
+++ b/hack/markdown-link-check.json
@@ -1,0 +1,8 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^(?!(https?://(pingcap.com|github.com|tikv.org)/|media/))"
+        }
+    ],
+    "replacementPatterns": []
+}

--- a/hack/verify-links.sh
+++ b/hack/verify-links.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This script is used to verify links in markdown docs.
+#
+
+ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+if ! which markdown-link-check &>/dev/null; then
+    sudo npm install -g markdown-link-check@3.7.3
+fi
+
+#
+# Currently, we only check pingcap.com/github.com/tikv.org links and media
+# static files. This is because external websites are beyond our control.
+#
+# TODO check more links
+#
+CONFIG_TMP=hack/markdown-link-check.json
+ERROR_REPORT=$(mktemp)
+
+trap 'rm -f $ERROR_REPORT' EXIT
+
+while read -r tasks; do
+    for task in $tasks; do
+        (
+            echo markdown-link-check --config "$CONFIG_TMP" "$task" -q
+            output=$(markdown-link-check --color --config "$CONFIG_TMP" "$task" -q)
+            if [ $? -ne 0 ]; then
+                printf "$output" >> $ERROR_REPORT
+            fi
+            echo "$output"
+        ) &
+    done
+    wait
+done <<<"$(find . -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 | xargs -0 -n 30)"
+
+error_files=$(cat $ERROR_REPORT | grep 'FILE: ' | wc -l)
+error_output=$(cat $ERROR_REPORT)
+
+echo ""
+if [ "$error_files" -gt 0 ]; then
+    echo "error: $error_files files have invalid links, please fix them!"
+    echo ""
+    echo "=== ERROR REPORT == ":
+    echo "$error_output"
+    exit 1
+else
+    echo "info: all files are ok!"
+fi


### PR DESCRIPTION
Help us to fix broken links. Currently, it only checks pingcap.com/github.com/tikv.org links and media static files.

**Update:** This script can run in CI (e.g. circle ci).

Current broken links:

```
FILE: ./what-is-new-in-tidb-3.0.0-beta.1.md
[✖] https://github.com/pingcap/docs-cn/blob/master/releases/3.0.0-beta.1.md
FILE: ./tidb-21-battle-tested-for-an-unpredictable-world.md
[✖] https://github.com/pingcap/docs/blob/master/benchmark/tpch.md
[✖] https://pingcap.com/docs/tools/tidb-binlog-cluster/
FILE: ./tidb-source-code-reading-11.md
[✖] https://github.com/pingcap/docs-cn/blob/master/sql/tidb-specific.md#tidb_inljt1-t2
FILE: ./tidb-21-ga-release-notes.md
[✖] https://github.com/pingcap/docs-cn/blob/master/v2.1/tools/pd-recover.md
[✖] https://github.com/tikv/tikv/blob/master/docs/tools/tikv-control.md#ldb-command
FILE: ./tidb-2.0-ga-release-detail.md
[✖] https://github.com/pingcap/docs-cn/blob/master/benchmark/tpch.md
FILE: ./tidb-community-guide-1.md
[✖] https://github.com/pingcap/docs/blob/master/ROADMAP.md
FILE: ./tidb-source-code-reading-22.md
[✖] https://github.com/pingcap/docs-cn/blob/master/sql/tidb-specific.md#tidb_hashagg_partial_concurrency
[✖] https://github.com/pingcap/docs-cn/blob/master/sql/tidb-specific.md#tidb_hashagg_final_concurrency
FILE: ./guiding-ideologies-in-the-evolution-of-tidb.md
[✖] https://github.com/pingcap/docs-cn/blob/master/v2.1/sql/tidb-specific.md
FILE: ./30mins-become-contributor-of-tikv.md
[✖] https://github.com/pingcap/tikv/blob/master/src/coprocessor/dag/expr/builtin_arithmetic.rs
FILE: ./tidb-source-code-reading-10.md
[✖] https://github.com/pingcap/docs-cn/blob/master/benchmark/tpch.md
```

It's better to use [github permanent links](https://help.github.com/en/articles/getting-permanent-links-to-files) in blog articles.